### PR TITLE
fixed takeScreenShotOnlyForFailedSpecs

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ ScreenshotReporter.prototype.specDone = function (spec) {
     				throw new Error('Could not create directory ' + directory);
     			} else {
     				util.addMetaData(metaData, metaDataPath, descriptions, self.finalOptions);
-    				if(!(self.takeScreenShotsOnlyForFailedSpecs && results.passedExpectations)) {
+    				if(!(self.takeScreenShotsOnlyForFailedSpecs && results.status === 'passed')) {
     					util.storeScreenShot(png, screenShotPath);
     				}
     				util.storeMetaData(metaData, metaDataPath);


### PR DESCRIPTION
takeScreenShotOnlyForFailedSpecs : true
would not save any screen shots,
as spec.passedExpectations is just an empty array in case of a failed spec, so it's still truthy and index.js:214 would have never been true.
